### PR TITLE
Add new cards content type

### DIFF
--- a/content/cards/1980-topps-482-rickey-henderson/back.svg
+++ b/content/cards/1980-topps-482-rickey-henderson/back.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="280">
+  <rect width="100%" height="100%" fill="#f0f0f0"/>
+  <text x="50" y="140" font-size="20" fill="#333">Back</text>
+</svg>

--- a/content/cards/1980-topps-482-rickey-henderson/front.svg
+++ b/content/cards/1980-topps-482-rickey-henderson/front.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="280">
+  <rect width="100%" height="100%" fill="#f0f0f0"/>
+  <text x="50" y="140" font-size="20" fill="#333">Front</text>
+</svg>

--- a/content/cards/1980-topps-482-rickey-henderson/index.md
+++ b/content/cards/1980-topps-482-rickey-henderson/index.md
@@ -1,0 +1,10 @@
+---
+title: "1980 Topps #482 Rickey Henderson"
+date: 2024-11-30
+---
+
+Rickey Henderson's iconic rookie card from the 1980 Topps set.
+
+<!--more-->
+
+These are my notes about the card. Details about condition, centering, corners, and personal significance go here.

--- a/content/cards/_index.md
+++ b/content/cards/_index.md
@@ -1,0 +1,5 @@
+---
+title: Cards
+---
+
+A collection of baseball cards with notes on each.

--- a/layouts/cards/single.html
+++ b/layouts/cards/single.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+<h2>{{ .Title }}</h2>
+<div>{{ partial "breadcrumb.html" . }}</div>
+<div>{{ .Date.Format "January 2, 2006" }}</div>
+
+{{ with .Resources.GetMatch "front.*" }}
+<div><img src="{{ .RelPermalink }}" alt="front of card"></div>
+{{ end }}
+{{ with .Resources.GetMatch "back.*" }}
+<div><img src="{{ .RelPermalink }}" alt="back of card"></div>
+{{ end }}
+
+{{ if .Params.toc }}{{ .TableOfContents }}{{ end }}
+
+{{ .Content }}
+
+<p>
+  {{ partial "tag-list.html" . }}
+</p>
+<p>
+  {{ with .GitInfo }}
+    <div style="opacity:0.3">
+      Updated At: {{ dateFormat "2006-01-02 15:04 -0700" .AuthorDate.Local }} (<a href="{{$.Site.Params.github_repo}}commit/{{ .Hash }}">{{ .AbbreviatedHash }}</a>)
+    </div>
+  {{ end }}
+</p>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,6 +37,16 @@
 </div>
 
 <div>
+  Newest Cards:
+  <ul>
+  {{ range first 10 (where .Site.RegularPages.ByDate.Reverse "Section" "cards") }}
+    <li><a href="{{ .Permalink }}">{{ .Title }}</a></li>
+  {{ end }}
+    <li><a href="{{ with .Site.GetPage "section" "cards" }}{{ .Permalink }}{{ end }}">More...</a></li>
+  </ul>
+</div>
+
+<div>
   Teams:
   <ul>
     {{range $name, $taxonomy := .Site.Taxonomies.teams}}


### PR DESCRIPTION
## Summary
- introduce `cards` section for single card write-ups
- show newest card entries on the home page
- layout for cards displays front and back images with notes
- example card: 1980 Topps #482 Rickey Henderson

## Testing
- `hugo --minify`

------
https://chatgpt.com/codex/tasks/task_e_6871f39ff8308323a05082d7ff0bb51a