### PR TITLE
Add Mike Norris tip entry

### DIFF
--- a/content/til/2025-08-17-mike-norris-george-brett-1980.md
+++ b/content/til/2025-08-17-mike-norris-george-brett-1980.md
@@ -1,0 +1,21 @@
+---
+title: "Mike Norris and George Brett in 1980"
+date: 2025-08-17
+players: ["mike-norris","george-brett"]
+teams: ["athletics","royals"]
+---
+
+Mike Norris won 20 games in 1980 for the A's, throwing 284.1 innings and 24 complete games. He finished second in the AL Cy Young race to Steve Stone of the Baltimore Orioles and received MVP votes that year.
+
+<!--more-->
+
+- Won back-to-back Gold Gloves in 1980 and 1981.
+- Was an All-Star in 1981.
+- Played exclusively for the Oakland A's.
+- Played in three decades: 1970s, 1980s, and 1990s.
+- Fought his way back to the big leagues as a reliever in 1990 after several years in the minors.
+
+In that same 1980 season, George Brett posted 9.4 WAR in just 117 games and captured his lone AL MVP award.
+
+- Hit .390 with a 1.118 OPS, which would have led the league had he qualified for the batting title.
+- Missed time between June 10 and July 10 and lost additional weeks in May and September.


### PR DESCRIPTION
## Summary
- add TIL entry for Mike Norris and George Brett's 1980 seasons with publish date 2025-08-17
- highlight Norris's 20 wins, 284.1 innings, 24 complete games, Cy Young runner-up with MVP votes, and 1981 All-Star selection
- note George Brett's 9.4 WAR in 117 games and .390 average despite significant missed time

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_68a29e43a5748323974b7b83259eff72