### PR TITLE
Add TIL entry on 1996 A's season opener in Las Vegas

### DIFF
--- a/content/til/2025-08-31-1996-as-las-vegas-opener.md
+++ b/content/til/2025-08-31-1996-as-las-vegas-opener.md
@@ -1,0 +1,16 @@
+---
+title: "1996 A's Opened Season in Las Vegas"
+date: 2025-08-31
+teams: ["athletics"]
+---
+
+The Athletics opened the 1996 season in Las Vegas at a minor league park while renovations to the Oakland Coliseum were still underway, the first major league games in a minor league venue since 1957.
+
+<!--more-->
+
+It served as a six-game opening homestand against the Blue Jays and Tigers from April 1–7, during which Oakland went 2–4. The finale on April 7 was a walk-off win over Detroit when Geronimo Berroa homered with Brent Gates aboard to flip a 5–6 deficit into a 7–6 victory. After a road trip the A's returned to Oakland for their second homestand on April 19.
+
+The temporary stint at Cashman Field foreshadowed Oakland's expected 2025–27 stay in Sacramento's minor league stadium before a planned move to Las Vegas in 2028.
+
+From the A’s website: "1996 - The Athletics open the season in Las Vegas since renovations to the Oakland Coliseum are still not finished. It is the first time since September 3, 1957 that major league teams have played in a minor league park."
+


### PR DESCRIPTION
## Summary
- expand Aug 31, 2025 TIL with specifics on the six-game Las Vegas opening homestand, 2-4 record, walk-off finale and return to Oakland

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68b456eb3d08832387cab7bc436c228a