### PR TITLE
Fix trailing slash configuration for site URLs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://mlb.tomhummel.com"
+baseURL = "https://mlb.tomhummel.com/"
 languageCode = "en-us"
 title = "Tom Hummel :: Baseball Blog"
 enableInlineShortcodes = true
@@ -12,7 +12,7 @@ enableGitInfo = true
 [params]
     Title = "Tom Hummel's Baseball Blog"
     site_description = "Baseball analysis, software, and writing."
-    github_repo = "https://github.com/tphummel/mlb.tomhummel.com"
+    github_repo = "https://github.com/tphummel/mlb.tomhummel.com/"
 
 [markup]
   [markup.tableOfContents]


### PR DESCRIPTION
## Summary
- add trailing slashes to the site base URL and GitHub repository URL in the Hugo config so generated links include separators

## Testing
- hugo --minify

------
https://chatgpt.com/codex/tasks/task_e_68d955ce3b808323b244fb98a61d6e41