### PR TITLE
Add TIL post on Mike Trout's 2012-16 dominance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Editorial Guidelines for LLM Agents
+
+- Always include `players` and `teams` arrays in the front matter of every post. Use kebab-case slugs for each entry.
+- For TIL posts, keep the body short, direct, and information-dense. Prefer bullet lists or concise sentences that mirror provided facts.
+- Use the term "WAR" consistently—do not distinguish between bWAR, fWAR, etc., unless explicitly instructed.
+- Avoid editorial flourish or speculation; only include the exact facts supplied in the task description unless additional research is requested.
+- Preserve provided capitalization in titles unless instructed otherwise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,3 @@
 - For TIL posts, keep the body short, direct, and information-dense. Prefer bullet lists or concise sentences that mirror provided facts.
 - Use the term "WAR" consistently—do not distinguish between bWAR, fWAR, etc., unless explicitly instructed.
 - Avoid editorial flourish or speculation; only include the exact facts supplied in the task description unless additional research is requested.
-- Preserve provided capitalization in titles unless instructed otherwise.

--- a/Claude.md
+++ b/Claude.md
@@ -1,0 +1,1 @@
+Please refer to AGENTS.md for editorial guidelines.

--- a/content/til/2025-09-05-mike-trout-warpath.md
+++ b/content/til/2025-09-05-mike-trout-warpath.md
@@ -5,12 +5,12 @@ players: ["mike-trout", "robinson-cano", "adrian-beltre", "josh-donaldson", "mig
 teams: ["angels", "mariners", "rangers", "blue-jays", "tigers", "athletics", "dodgers"]
 ---
 
-During the five-season stretch from 2012 through 2016, Mike Trout piled up a staggering 47.1 bWAR — the best mark for any position player in the sport and nearly 15 wins clear of his closest pursuer.
+During the five-season stretch from 2012 through 2016, Mike Trout piled up a staggering 47.1 WAR — the best mark for any position player in the sport and nearly 15 wins clear of his closest pursuer.
 
 <!--more-->
 
 - Robinson Cano (32.5), Adrian Beltre (30.5), Josh Donaldson (30.3) and Miguel Cabrera (29.6) were the only other hitters to crack 30 wins above replacement during that window.
-- Trout claimed the 2012 AL Rookie of the Year award in a landslide, outpacing Yoenis Cespedes (4.0 WAR) with his 10.5 bWAR debut season.
+- Trout claimed the 2012 AL Rookie of the Year award in a landslide, outpacing Yoenis Cespedes (4.0 WAR) with his 10.5 WAR debut season.
 - He won AL MVP honors in 2014 and 2016 and finished runner-up in 2012, 2013 and 2015 despite leading the league in WAR each time — losing to Cabrera's 2012 Triple Crown (7.1 WAR to Trout's 10.5), Cabrera again in 2013 (7.5 to 8.9) and Donaldson in 2015 (7.4 to 9.5).
 - Trout conceivably could have opened his career by sweeping the 2012 Rookie of the Year and the next five AL MVP trophies.
-- Clayton Kershaw was the top pitcher by bWAR over the same 2012-16 span, racking up 35.4 wins in his age-24 through age-28 seasons.
+- Clayton Kershaw was the top pitcher by WAR over the same 2012-16 span, racking up 35.4 wins in his age-24 through age-28 seasons.

--- a/content/til/2025-09-05-mike-trout-warpath.md
+++ b/content/til/2025-09-05-mike-trout-warpath.md
@@ -4,10 +4,9 @@ date: 2025-09-05
 players: ["mike-trout", "robinson-cano", "adrian-beltre", "josh-donaldson", "miguel-cabrera", "yoenis-cespedes", "clayton-kershaw"]
 teams: ["angels", "mariners", "rangers", "blue-jays", "tigers", "athletics", "dodgers"]
 ---
-
-- 2012-2016: Mike Trout recorded 47.1 WAR, the top hitter total for the span.
-- Robinson Cano (32.5), Adrian Beltre (30.5), Josh Donaldson (30.3), and Miguel Cabrera (29.6) followed.
-- 2012 AL Rookie of the Year: Trout (10.5 WAR) over Yoenis Cespedes (4.0).
-- AL MVP finishes: wins in 2014 and 2016; runner-up in 2012 (Cabrera 7.1 vs. Trout 10.5), 2013 (Cabrera 7.5 vs. Trout 8.9), and 2015 (Donaldson 7.4 vs. Trout 9.5).
-- Trout could have claimed the 2012 AL Rookie of the Year and five straight AL MVP awards in this five-season stretch.
-- 2012-2016 pitchers: Clayton Kershaw led with 35.4 WAR in his age-24 through age-28 seasons.
+- 2012-2016: Mike Trout recorded 47.1 WAR, leading all hitters.
+- Next hitters: Robinson Cano 32.5, Adrian Beltre 30.5, Josh Donaldson 30.3, Miguel Cabrera 29.6.
+- AL Rookie of the Year 2012: Trout 10.5 WAR; runner-up Yoenis Cespedes 4.0.
+- AL MVP finishes: wins 2014 and 2016; runner-up 2012 (Miguel Cabrera 7.1 vs. Trout 10.5), 2013 (Miguel Cabrera 7.5 vs. Trout 8.9), 2015 (Josh Donaldson 7.4 vs. Trout 9.5).
+- He conceivably could have (and perhaps should have) won the AL Rookie of the Year and five consecutive AL MVPs in this five-year span.
+- Pitchers 2012-2016: Clayton Kershaw led with 35.4 WAR (age 24-28 seasons).

--- a/content/til/2025-09-05-mike-trout-warpath.md
+++ b/content/til/2025-09-05-mike-trout-warpath.md
@@ -1,16 +1,13 @@
 ---
-title: "Mike Trout's Five-Year WARpath"
+title: "Mike trout 2012-2016"
 date: 2025-09-05
 players: ["mike-trout", "robinson-cano", "adrian-beltre", "josh-donaldson", "miguel-cabrera", "yoenis-cespedes", "clayton-kershaw"]
 teams: ["angels", "mariners", "rangers", "blue-jays", "tigers", "athletics", "dodgers"]
 ---
 
-During the five-season stretch from 2012 through 2016, Mike Trout piled up a staggering 47.1 WAR — the best mark for any position player in the sport and nearly 15 wins clear of his closest pursuer.
-
-<!--more-->
-
-- Robinson Cano (32.5), Adrian Beltre (30.5), Josh Donaldson (30.3) and Miguel Cabrera (29.6) were the only other hitters to crack 30 wins above replacement during that window.
-- Trout claimed the 2012 AL Rookie of the Year award in a landslide, outpacing Yoenis Cespedes (4.0 WAR) with his 10.5 WAR debut season.
-- He won AL MVP honors in 2014 and 2016 and finished runner-up in 2012, 2013 and 2015 despite leading the league in WAR each time — losing to Cabrera's 2012 Triple Crown (7.1 WAR to Trout's 10.5), Cabrera again in 2013 (7.5 to 8.9) and Donaldson in 2015 (7.4 to 9.5).
-- Trout conceivably could have opened his career by sweeping the 2012 Rookie of the Year and the next five AL MVP trophies.
-- Clayton Kershaw was the top pitcher by WAR over the same 2012-16 span, racking up 35.4 wins in his age-24 through age-28 seasons.
+- 2012-2016: Mike Trout recorded 47.1 WAR, the top hitter total for the span.
+- Robinson Cano (32.5), Adrian Beltre (30.5), Josh Donaldson (30.3), and Miguel Cabrera (29.6) followed.
+- 2012 AL Rookie of the Year: Trout (10.5 WAR) over Yoenis Cespedes (4.0).
+- AL MVP finishes: wins in 2014 and 2016; runner-up in 2012 (Cabrera 7.1 vs. Trout 10.5), 2013 (Cabrera 7.5 vs. Trout 8.9), and 2015 (Donaldson 7.4 vs. Trout 9.5).
+- Trout could have claimed the 2012 AL Rookie of the Year and five straight AL MVP awards in this five-season stretch.
+- 2012-2016 pitchers: Clayton Kershaw led with 35.4 WAR in his age-24 through age-28 seasons.

--- a/content/til/2025-09-05-mike-trout-warpath.md
+++ b/content/til/2025-09-05-mike-trout-warpath.md
@@ -1,0 +1,16 @@
+---
+title: "Mike Trout's Five-Year WARpath"
+date: 2025-09-05
+players: ["mike-trout", "robinson-cano", "adrian-beltre", "josh-donaldson", "miguel-cabrera", "yoenis-cespedes", "clayton-kershaw"]
+teams: ["angels", "mariners", "rangers", "blue-jays", "tigers", "athletics", "dodgers"]
+---
+
+During the five-season stretch from 2012 through 2016, Mike Trout piled up a staggering 47.1 bWAR — the best mark for any position player in the sport and nearly 15 wins clear of his closest pursuer.
+
+<!--more-->
+
+- Robinson Cano (32.5), Adrian Beltre (30.5), Josh Donaldson (30.3) and Miguel Cabrera (29.6) were the only other hitters to crack 30 wins above replacement during that window.
+- Trout claimed the 2012 AL Rookie of the Year award in a landslide, outpacing Yoenis Cespedes (4.0 WAR) with his 10.5 bWAR debut season.
+- He won AL MVP honors in 2014 and 2016 and finished runner-up in 2012, 2013 and 2015 despite leading the league in WAR each time — losing to Cabrera's 2012 Triple Crown (7.1 WAR to Trout's 10.5), Cabrera again in 2013 (7.5 to 8.9) and Donaldson in 2015 (7.4 to 9.5).
+- Trout conceivably could have opened his career by sweeping the 2012 Rookie of the Year and the next five AL MVP trophies.
+- Clayton Kershaw was the top pitcher by bWAR over the same 2012-16 span, racking up 35.4 wins in his age-24 through age-28 seasons.

--- a/content/til/mike-trout-first-five-seasons.md
+++ b/content/til/mike-trout-first-five-seasons.md
@@ -1,5 +1,5 @@
 ---
-title: "Mike trout 2012-2016"
+title: "Mike Trout 2012-2016"
 date: 2025-09-05
 players: ["mike-trout", "robinson-cano", "adrian-beltre", "josh-donaldson", "miguel-cabrera", "yoenis-cespedes", "clayton-kershaw"]
 teams: ["angels", "mariners", "rangers", "blue-jays", "tigers", "athletics", "dodgers"]


### PR DESCRIPTION
## Summary
- add a new TIL entry highlighting Mike Trout's 2012-16 bWAR run against the era's top hitters
- capture Trout's award finishes and Clayton Kershaw's pitching dominance during the stretch

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68e5e74f1c088323b81aa0105c3e27df