### PR TITLE
add Jim Corsi TIL

### DIFF
--- a/content/til/2025-11-24-jim-corsi-babip.md
+++ b/content/til/2025-11-24-jim-corsi-babip.md
@@ -1,0 +1,15 @@
+---
+title: "Jim Corsi's 1989 BABIP"
+date: 2025-11-24
+players: ["jim-corsi"]
+teams: ["athletics"]
+---
+
+Jim Corsi's 1989 A's bullpen line was a BABIP standout.
+
+<!--more-->
+
+- Threw 38.1 innings and faced 149 batters with a .188 average against and 0.94 WHIP.
+- Allowed 26 hits (2 homers), 21 strikeouts, 10 walks, and 1 hit-by-pitch; 58 plate appearances ended with a walk, strikeout, hit, or HBP.
+- The remaining 91 balls in play went for outs, yielding a .212 BABIP.
+- Sixteen pitchers in the 1980s logged seasons under .200 BABIP with at least 100 batters faced, so his mark was low but not unique.


### PR DESCRIPTION
## Summary
- move Jim Corsi BABIP TIL entry to November 24, 2025

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69258d17f3d48323b72614c982364fdf)