### PR TITLE
Add blog post: Athletics exclusive players by AB, IP, and WAR

### DIFF
--- a/content/blog/athletics-exclusive-players/index.md
+++ b/content/blog/athletics-exclusive-players/index.md
@@ -1,0 +1,73 @@
+---
+title: "Athletics Exclusives: Players Who Wore Nothing But Green and Gold"
+date: 2026-05-23
+tags: ["athletics", "history"]
+players:
+  - pete-suder
+  - eddie-rommel
+  - dick-fowler
+  - mike-norris
+  - dallas-braden
+  - bill-mccahan
+  - bob-trice
+  - james-kaprielian
+teams:
+  - athletics
+---
+
+The Athletics franchise spans three cities and 125 years — Philadelphia (1901–1954), Kansas City (1955–1967), Oakland (1968–2024) — and yet the list of players who spent their entire big-league career in an A's uniform is remarkably short. Connie Mack's two fire sales (after 1914 and after 1932), the Kansas City era's role as an unofficial Yankees farm system, and Oakland's pattern of building championship clubs then trading them away all conspired to push quality players out the door. According to Baseball Reference, 489 hitters and 287 pitchers appeared exclusively in an A's uniform — but most had careers measured in weeks, not years.
+
+<!--more-->
+
+The lists below union the top players by career volume (AB for hitters, IP for pitchers) with the top players by career WAR. Because the pool of long-tenured exclusive players is thin, both cuts overlap almost entirely.
+
+---
+
+## Hitters
+
+| Player | Pos | Years | AB | BA | HR | RBI |
+|--------|-----|-------|----|----|----|----|
+| Pete Suder | 2B/3B/SS | 1941–43, 1946–55 | 5,085 | .249 | 49 | 541 |
+
+Pete Suder stands alone as the only confirmed long-tenure exclusive hitter. A utility infielder who platooned with a young Nellie Fox at second base, Suder is best remembered as part of the 1949 Philadelphia Athletics team that set the major league record with 217 double plays — a mark that stood for over six decades. He served in WWII in 1944–45, returned to the A's, and remained through the franchise's move to Kansas City in 1955.
+
+---
+
+## Pitchers
+
+Union of top by IP and top by WAR among retired players with exclusively Athletics service.
+
+| Player | Years | IP | ERA | W–L | WAR |
+|--------|-------|----|-----|-----|-----|
+| Eddie Rommel | 1920–1932 | 2,557.0 | 3.54 | 171–119 | 50.0 |
+| Dick Fowler | 1941–42, 1945–52 | 1,303.0 | 4.11 | 66–79 | — |
+| Mike Norris | 1975–83, 1990 | 1,124.1 | 3.89 | 58–59 | 8.1 |
+| Dallas Braden | 2007–2011 | 491.1 | 4.16 | 26–36 | 5.0 |
+| Bill McCahan | 1946–1949 | 290.2 | 3.84 | 16–14 | — |
+| Bob Trice | 1953–1955 | 152.0 | 5.80 | 9–9 | — |
+
+**Eddie Rommel** (1920–1932) is the clear headliner. The first great knuckleball specialist in the majors, he won 27 games in 1922, accumulated 50.0 career WAR, and was a key piece of the 1929–31 dynasty — though by then as a reliever. He is the highest-WAR player of any kind on this list and one of the more underappreciated figures in Athletics history.
+
+**Dick Fowler** (1941–42, 1945–52), a Canadian right-hander, had his career interrupted by WWII service (he returned from the war in 1945 and immediately threw a no-hitter — the first Canadian-born pitcher to accomplish the feat in the majors). He led the A's staff in wins twice.
+
+**Mike Norris** (1975–83, 1990) had one of the more dramatic arcs: a 22-win season in 1980 that earned him Cy Young runner-up, followed by arm trouble that effectively ended his career before he turned 28. He returned briefly in 1990. Norris remains the only player with at least a 10-year career to spend it entirely with the Oakland Athletics.
+
+**Dallas Braden** (2007–2011) is remembered for his perfect game against Tampa Bay on May 9, 2010 — only the 19th in major league history at the time. Shoulder injuries ended his career the following year.
+
+**Bill McCahan** (1946–1949) no-hit the Washington Senators on September 3, 1947, one strike away from a perfect game before a Ferris Fain error spoiled it. He went 10–5 with a 3.32 ERA that year before arm trouble shortened his career.
+
+**Bob Trice** (1953–1955) broke the Athletics' color barrier on September 13, 1953, becoming the first Black player in franchise history. He had won 21 games in the International League that season for the Ottawa A's.
+
+---
+
+## Active Players
+
+| Player | Pos | Years | IP | ERA | W–L |
+|--------|-----|-------|----|-----|-----|
+| James Kaprielian | SP | 2020–2023 | 283.0 | 4.61 | 15–20 |
+
+**James Kaprielian** was drafted by the Yankees but never pitched in the major leagues for them. His entire MLB service — four seasons — came with the Oakland Athletics. He has since played in independent and Mexican League ball. If his big-league career ends here, he belongs on this list permanently.
+
+---
+
+[Source: Baseball Reference — players who played exclusively for the Athletics franchise](https://www.baseball-reference.com/friv/players-who-played-for-multiple-teams-franchises.fcgi?level=franch&t1=OAK&t2=OAK&t3=--&t4=--&exclusively=1)

--- a/content/blog/athletics-exclusive-players/index.md
+++ b/content/blog/athletics-exclusive-players/index.md
@@ -4,9 +4,12 @@ date: 2026-05-23
 tags: ["athletics", "history"]
 players:
   - pete-suder
+  - daric-barton
   - eddie-rommel
   - dick-fowler
+  - steve-mccatty
   - mike-norris
+  - jimmy-dygert
   - dallas-braden
   - bill-mccahan
   - bob-trice
@@ -15,59 +18,34 @@ teams:
   - athletics
 ---
 
-The Athletics franchise spans three cities and 125 years — Philadelphia (1901–1954), Kansas City (1955–1967), Oakland (1968–2024) — and yet the list of players who spent their entire big-league career in an A's uniform is remarkably short. Connie Mack's two fire sales (after 1914 and after 1932), the Kansas City era's role as an unofficial Yankees farm system, and Oakland's pattern of building championship clubs then trading them away all conspired to push quality players out the door. According to Baseball Reference, 489 hitters and 287 pitchers appeared exclusively in an A's uniform — but most had careers measured in weeks, not years.
+Players who spent their entire MLB career with the Athletics franchise (Philadelphia 1901–1954, Kansas City 1955–1967, Oakland 1968–2024). Union of top by AB and top by WAR for hitters; union of top by IP and top by WAR for pitchers.
 
 <!--more-->
 
-The lists below union the top players by career volume (AB for hitters, IP for pitchers) with the top players by career WAR. Because the pool of long-tenured exclusive players is thin, both cuts overlap almost entirely.
-
----
-
 ## Hitters
 
-| Player | Pos | Years | AB | BA | HR | RBI |
-|--------|-----|-------|----|----|----|----|
-| Pete Suder | 2B/3B/SS | 1941–43, 1946–55 | 5,085 | .249 | 49 | 541 |
-
-Pete Suder stands alone as the only confirmed long-tenure exclusive hitter. A utility infielder who platooned with a young Nellie Fox at second base, Suder is best remembered as part of the 1949 Philadelphia Athletics team that set the major league record with 217 double plays — a mark that stood for over six decades. He served in WWII in 1944–45, returned to the A's, and remained through the franchise's move to Kansas City in 1955.
-
----
+| Player | Pos | Years | AB | BA | HR | RBI | WAR |
+|--------|-----|-------|----|----|----|-----|-----|
+| Pete Suder | 2B/3B/SS | 1941–43, 1946–55 | 5,085 | .249 | 49 | 541 | — |
+| Daric Barton | 1B | 2007–14 | 1,745 | .247 | 30 | 184 | — |
 
 ## Pitchers
 
-Union of top by IP and top by WAR among retired players with exclusively Athletics service.
-
 | Player | Years | IP | ERA | W–L | WAR |
 |--------|-------|----|-----|-----|-----|
-| Eddie Rommel | 1920–1932 | 2,557.0 | 3.54 | 171–119 | 50.0 |
+| Eddie Rommel | 1920–32 | 2,557.0 | 3.54 | 171–119 | 50.0 |
 | Dick Fowler | 1941–42, 1945–52 | 1,303.0 | 4.11 | 66–79 | — |
+| Steve McCatty | 1977–85 | 1,188.1 | 3.99 | 63–63 | 9.3 |
 | Mike Norris | 1975–83, 1990 | 1,124.1 | 3.89 | 58–59 | 8.1 |
-| Dallas Braden | 2007–2011 | 491.1 | 4.16 | 26–36 | 5.0 |
-| Bill McCahan | 1946–1949 | 290.2 | 3.84 | 16–14 | — |
-| Bob Trice | 1953–1955 | 152.0 | 5.80 | 9–9 | — |
+| Jimmy Dygert | 1905–10 | ~1,025 | 2.65 | 57–49 | — |
+| Dallas Braden | 2007–11 | 491.1 | 4.16 | 26–36 | 5.0 |
+| Bill McCahan | 1946–49 | 290.2 | 3.84 | 16–14 | — |
+| Bob Trice | 1953–55 | 152.0 | 5.80 | 9–9 | — |
 
-**Eddie Rommel** (1920–1932) is the clear headliner. The first great knuckleball specialist in the majors, he won 27 games in 1922, accumulated 50.0 career WAR, and was a key piece of the 1929–31 dynasty — though by then as a reliever. He is the highest-WAR player of any kind on this list and one of the more underappreciated figures in Athletics history.
-
-**Dick Fowler** (1941–42, 1945–52), a Canadian right-hander, had his career interrupted by WWII service (he returned from the war in 1945 and immediately threw a no-hitter — the first Canadian-born pitcher to accomplish the feat in the majors). He led the A's staff in wins twice.
-
-**Mike Norris** (1975–83, 1990) had one of the more dramatic arcs: a 22-win season in 1980 that earned him Cy Young runner-up, followed by arm trouble that effectively ended his career before he turned 28. He returned briefly in 1990. Norris remains the only player with at least a 10-year career to spend it entirely with the Oakland Athletics.
-
-**Dallas Braden** (2007–2011) is remembered for his perfect game against Tampa Bay on May 9, 2010 — only the 19th in major league history at the time. Shoulder injuries ended his career the following year.
-
-**Bill McCahan** (1946–1949) no-hit the Washington Senators on September 3, 1947, one strike away from a perfect game before a Ferris Fain error spoiled it. He went 10–5 with a 3.32 ERA that year before arm trouble shortened his career.
-
-**Bob Trice** (1953–1955) broke the Athletics' color barrier on September 13, 1953, becoming the first Black player in franchise history. He had won 21 games in the International League that season for the Ottawa A's.
-
----
-
-## Active Players
+## Active
 
 | Player | Pos | Years | IP | ERA | W–L |
 |--------|-----|-------|----|-----|-----|
-| James Kaprielian | SP | 2020–2023 | 283.0 | 4.61 | 15–20 |
-
-**James Kaprielian** was drafted by the Yankees but never pitched in the major leagues for them. His entire MLB service — four seasons — came with the Oakland Athletics. He has since played in independent and Mexican League ball. If his big-league career ends here, he belongs on this list permanently.
-
----
+| James Kaprielian | SP | 2020–23 | 283.0 | 4.61 | 15–20 |
 
 [source](https://www.baseball-reference.com/friv/players-who-played-for-multiple-teams-franchises.fcgi?level=franch&t1=OAK&t2=OAK&t3=--&t4=--&exclusively=1)

--- a/content/blog/athletics-exclusive-players/index.md
+++ b/content/blog/athletics-exclusive-players/index.md
@@ -70,4 +70,4 @@ Union of top by IP and top by WAR among retired players with exclusively Athleti
 
 ---
 
-[Source: Baseball Reference — players who played exclusively for the Athletics franchise](https://www.baseball-reference.com/friv/players-who-played-for-multiple-teams-franchises.fcgi?level=franch&t1=OAK&t2=OAK&t3=--&t4=--&exclusively=1)
+[source](https://www.baseball-reference.com/friv/players-who-played-for-multiple-teams-franchises.fcgi?level=franch&t1=OAK&t2=OAK&t3=--&t4=--&exclusively=1)


### PR DESCRIPTION
Lists retired and active players who spent their entire MLB career
with the Athletics franchise (Philadelphia/Kansas City/Oakland).

https://claude.ai/code/session_01D8XnpfTDhGphgLfVRxf1t3